### PR TITLE
イベント編集機能、削除機能

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -31,7 +31,6 @@ class EventsController < ApplicationController
   end
 
   def destroy
-
     @event.destroy!
     redirect_to root_path, notice: '削除しました'
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,6 @@
 class EventsController < ApplicationController
   before_action :authenticate, except: :show
+  before_action :set_event, only: [:edit, :update, :destroy]
 
   def new
     @event = current_user.created_events.build
@@ -39,5 +40,9 @@ class EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(:name, :place, :content, :start_time, :end_time)
+  end
+
+  def set_event
+    @event = current_user.created_events.find(params[:id])
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,6 +18,23 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
   end
 
+  def edit
+  end
+
+  def update
+    if @event.update(event_params)
+      redirect_to @event, notice: '更新しました'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+
+    @event.destroy!
+    redirect_to root_path, notice: '削除しました'
+  end
+
   private
 
   def event_params

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,11 @@ class Event < ApplicationRecord
   validates :end_time, presence: true
   validate :start_time_should_be_before_end_time
 
+  def created_by?(user)
+    return false unless user
+    owner_id == user.id
+  end
+
   private
 
   def start_time_should_be_before_end_time

--- a/app/views/events/edit.html.slim
+++ b/app/views/events/edit.html.slim
@@ -1,0 +1,28 @@
+- now = Time.zone.now 
+
+.page-header
+  h1 イベント情報編集
+  
+= form_for(@event, class: 'form-horizontal', role: 'form') do |f|
+  - if @event.errors.any?
+    .alert.alert-danger
+      ul
+        - @event.errors.full_messages.each do |msg|
+          li = msg
+          
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control'
+  .form-group
+    = f.label :place
+    = f.text_field :place, class: 'form-control'
+  .form-group
+    = f.label :start_time
+    = f.datetime_select :start_time, start_year: now.year, end_year: now.year + 1
+  .form-group
+    = f.label :end_time
+    = f.datetime_select :end_time, start_year: now.year, end_year: now.year + 1
+  .form-group
+    = f.label :content
+    = f.text_area :content, class: 'form-control', row: 10
+  = f.submit '更新', class: 'btn btn-default', data: { disable_with: '作成中…' }    

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -1,26 +1,32 @@
 .page-header
   h1 = @event.name
   
-.panel.panel-default
-  .panel-heading 主催者
-  .panel-body
-    = link_to("https://twitter.com/#{@event.owner.nickname}") do
-      = image_tag @event.owner.image_url
-      = "@#{p@event.owner.nickname}"
+.row
+  .col-md-8
+    .panel.panel-default
+      .panel-heading 主催者
+      .panel-body
+        = link_to("https://twitter.com/#{@event.owner.nickname}") do
+          = image_tag @event.owner.image_url
+          = "@#{p@event.owner.nickname}"
 
-.panel.panel-default
-  .panel-heading 開催時間
-  .panel-body
-    = "#{start_time(@event)} - "
-    = end_time(@event)
+    .panel.panel-default
+      .panel-heading 開催時間
+      .panel-body
+        = "#{start_time(@event)} - "
+        = end_time(@event)
 
-.panel.panel-default
-  .panel-heading 開催場所
-  .panel-body
-    = @event.place
+    .panel.panel-default
+      .panel-heading 開催場所
+      .panel-body
+        = @event.place
 
-.panel.panel-default
-  .panel-heading イベント内容
-  .panel-body
-    = @event.content
-    
+    .panel.panel-default
+      .panel-heading イベント内容
+      .panel-body
+        = @event.content
+        
+  .col-md-4
+    - if @event.created_by?(current_user)
+      = link_to 'イベントを編集する', edit_event_path(@event), class: 'btn btn-info btn-lg btn-block'
+      = link_to 'イベントを削除する', event_path(@event), method: :delete, class: 'btn btn-danger btn-lg btn-block', data: { confirm: '本当に削除しますか？' }


### PR DESCRIPTION
# what
- イベント詳細ページに「イベントを編集する」ボタンの追加
- イベント編集フォームの表示
- イベント編集フォームで間違った入力を行うとエラーメッセージの表示
- イベント編集フォームで正しく入力をすると、イベントが更新される
- イベント詳細ページに「イベントを削除する」ボタンの追加
- イベント削除ボタンを押すと、確認ダイアログを表示して、その後にイベントを削除することが出来る

# why
イベントを編集、削除出来るようにするため